### PR TITLE
Sticky Partition Assignor

### DIFF
--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -2,7 +2,6 @@ package sarama
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"sort"
 
@@ -1004,7 +1003,7 @@ func (p *partitionMovements) hasCycles(pairs []consumerPair) bool {
 		if path, linked := p.isLinked(pair.dstMemberID, pair.srcMemberID, reducedPairs, []string{pair.srcMemberID}); linked {
 			if !p.in(path, cycles) {
 				cycles = append(cycles, path)
-				log.Printf("A cycle of length %d was found: %v", len(path)-1, path)
+				Logger.Printf("A cycle of length %d was found: %v", len(path)-1, path)
 			}
 		}
 	}

--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -72,10 +72,17 @@ var BalanceStrategyRoundRobin = &balanceStrategy{
 	},
 }
 
-// BalanceStrategySticky assigns partitions to members with a bias toward preserving earlier assignments.
+// BalanceStrategySticky assigns partitions to members with an attempt to preserve earlier assignments
+// while maintain a balanced partition distribution.
 // Example with topic T with six partitions (0..5) and two members (M1, M2):
 //   M1: {T: [0, 2, 4]}
 //   M2: {T: [1, 3, 5]}
+//
+// On reassignment with an additional consumer, you might get an assignment plan like:
+//   M1: {T: [0, 2]}
+//   M2: {T: [1, 3]}
+//   M3: {T: [4, 5]}
+//
 var BalanceStrategySticky = &stickyBalanceStrategy{}
 
 // --------------------------------------------------------------------

--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -865,7 +865,7 @@ func (p *partitionMovements) movePartition(partition topicPartitionAssignment, o
 			Logger.Printf("Existing pair DstMemberID %s was not equal to the oldConsumer ID %s", existingPair.DstMemberID, oldConsumer)
 		}
 		if existingPair.SrcMemberID != newConsumer {
-			// the partition is not moving back to its previous consume
+			// the partition is not moving back to its previous consumer
 			p.addPartitionMovementRecord(partition, consumerPair{
 				SrcMemberID: existingPair.SrcMemberID,
 				DstMemberID: newConsumer,

--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	DefaultGeneration = -1
+	defaultGeneration = -1
 )
 
 // BalanceStrategyPlan is the results of any BalanceStrategy.Plan attempt.
@@ -787,10 +787,10 @@ func prepopulateCurrentAssignments(members map[string]ConsumerGroupMemberMetadat
 						consumers[consumerUserData.generation()] = memberID
 					}
 				} else {
-					consumers[DefaultGeneration] = memberID
+					consumers[defaultGeneration] = memberID
 				}
 			} else {
-				generation := DefaultGeneration
+				generation := defaultGeneration
 				if consumerUserData.hasGeneration() {
 					generation = consumerUserData.generation()
 				}

--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -1,8 +1,13 @@
 package sarama
 
 import (
+	"log"
 	"math"
 	"sort"
+)
+
+const (
+	DefaultGeneration = -1
 )
 
 // BalanceStrategyPlan is the results of any BalanceStrategy.Plan attempt.
@@ -68,6 +73,12 @@ var BalanceStrategyRoundRobin = &balanceStrategy{
 	},
 }
 
+// BalanceStrategySticky assigns partitions to members with a bias toward preserving earlier assignments.
+// Example with topic T with six partitions (0..5) and two members (M1, M2):
+//   M1: {T: [0, 2, 4]}
+//   M2: {T: [1, 3, 5]}
+var BalanceStrategySticky = &stickyBalanceStrategy{}
+
 // --------------------------------------------------------------------
 
 type balanceStrategy struct {
@@ -126,4 +137,865 @@ func balanceStrategyHashValue(vv ...string) uint32 {
 		}
 	}
 	return h
+}
+
+type stickyBalanceStrategy struct {
+}
+
+// Name implements BalanceStrategy.
+func (s *stickyBalanceStrategy) Name() string { return "sticky" }
+
+// Plan implements BalanceStrategy.
+func (s *stickyBalanceStrategy) Plan(members map[string]ConsumerGroupMemberMetadata, topics map[string][]int32) (BalanceStrategyPlan, error) {
+	movements := partitionMovements{}
+	currentAssignment, prevAssignment, err := prepopulateCurrentAssignments(members)
+	if err != nil {
+		return nil, err
+	}
+	var isFreshAssignment bool
+	if len(currentAssignment) == 0 {
+		isFreshAssignment = true
+	}
+
+	// a mapping of all topic partitions to all consumers that can be assigned to them
+	partition2AllPotentialConsumers := make(map[topicPartitionAssignment][]string)
+	for topic, partitions := range topics {
+		for _, partition := range partitions {
+			partition2AllPotentialConsumers[topicPartitionAssignment{Topic: topic, Partition: partition}] = make([]string, 0)
+		}
+	}
+
+	// a mapping of all consumers to all potential topic partitions that can be assigned to them
+	consumer2AllPotentialPartitions := make(map[string][]topicPartitionAssignment)
+	for memberID, meta := range members {
+		consumer2AllPotentialPartitions[memberID] = make([]topicPartitionAssignment, 0)
+		for _, topicSubscription := range meta.Topics {
+			// only evaluate topic subscriptions that are present in the supplied topics map
+			if _, found := topics[topicSubscription]; found {
+				for topic, partitions := range topics {
+					for _, partition := range partitions {
+						topicPartition := topicPartitionAssignment{Topic: topic, Partition: partition}
+						consumer2AllPotentialPartitions[memberID] = append(consumer2AllPotentialPartitions[memberID], topicPartition)
+						partition2AllPotentialConsumers[topicPartition] = append(partition2AllPotentialConsumers[topicPartition], memberID)
+					}
+				}
+			}
+		}
+
+		// add this consumer to currentAssignment (with an empty topic partition assignment) if it does not already exist
+		if _, exists := currentAssignment[memberID]; !exists {
+			currentAssignment[memberID] = make([]topicPartitionAssignment, 0)
+		}
+	}
+
+	// a mapping of partition to current consumer
+	currentPartitionConsumer := make(map[topicPartitionAssignment]string)
+	for consumerID, subscriptions := range currentAssignment {
+		for _, partition := range subscriptions {
+			currentPartitionConsumer[partition] = consumerID
+		}
+	}
+
+	sortedPartitions := sortPartitions(currentAssignment, prevAssignment, isFreshAssignment, partition2AllPotentialConsumers, consumer2AllPotentialPartitions)
+	unassignedPartitions := deepCopyPartitions(sortedPartitions)
+	for memberID, partitions := range currentAssignment {
+		// if a consumer that existed before (and had some partition assignments) is now removed, remove it from currentAssignment
+		if _, exists := members[memberID]; !exists {
+			for _, partition := range partitions {
+				delete(currentPartitionConsumer, partition)
+			}
+			delete(currentAssignment, memberID)
+			continue
+		}
+
+		// otherwise (the consumer still exists)
+		for i, partition := range partitions {
+			if _, exists := partition2AllPotentialConsumers[partition]; !exists {
+				// if this topic partition of this consumer no longer exists remove it from currentAssignment of the consumer
+				partitions = removeIndexFromPartitionSlice(partitions, i)
+				delete(currentPartitionConsumer, partition)
+			} else if _, exists := topics[partition.Topic]; !exists {
+				// if this partition cannot remain assigned to its current consumer because the consumer
+				// is no longer subscribed to its topic remove it from currentAssignment of the consumer
+				partitions = removeIndexFromPartitionSlice(partitions, i)
+			} else {
+				// otherwise, remove the topic partition from those that need to be assigned only if
+				// its current consumer is still subscribed to its topic (because it is already assigned
+				// and we would want to preserve that assignment as much as possible)
+				unassignedPartitions = removeTopicPartitionFromMemberAssignments(unassignedPartitions, partition)
+			}
+		}
+	}
+
+	// at this point we have preserved all valid topic partition to consumer assignments and removed
+	// all invalid topic partitions and invalid consumers. Now we need to assign unassignedPartitions
+	// to consumers so that the topic partition assignments are as balanced as possible.
+
+	// a descending sorted set of consumers based on how many topic partitions are already assigned to them
+	sortedCurrentSubscriptions := sortMemberIDsByPartitionAssignments(currentAssignment)
+	balance(movements, currentAssignment, prevAssignment, sortedPartitions, unassignedPartitions, sortedCurrentSubscriptions, consumer2AllPotentialPartitions, partition2AllPotentialConsumers, currentPartitionConsumer)
+
+	// Assemble plan
+	plan := make(BalanceStrategyPlan)
+	for memberID, assignments := range currentAssignment {
+		for _, assignment := range assignments {
+			plan.Add(memberID, assignment.Topic, assignment.Partition)
+		}
+	}
+	return plan, nil
+}
+
+func balance(movements partitionMovements, currentAssignment map[string][]topicPartitionAssignment, prevAssignment map[topicPartitionAssignment]consumerGenerationPair, sortedPartitions []topicPartitionAssignment, unassignedPartitions []topicPartitionAssignment, sortedCurrentSubscriptions []string, consumer2AllPotentialPartitions map[string][]topicPartitionAssignment, partition2AllPotentialConsumers map[topicPartitionAssignment][]string, currentPartitionConsumer map[topicPartitionAssignment]string) {
+	initializing := false
+	if len(sortedCurrentSubscriptions) == 0 || len(currentAssignment[sortedCurrentSubscriptions[0]]) == 0 {
+		initializing = true
+	}
+
+	// assign all unassigned partitions
+	for _, partition := range unassignedPartitions {
+		// skip if there is no potential consumer for the partition
+		if len(partition2AllPotentialConsumers[partition]) == 0 {
+			continue
+		}
+		sortedCurrentSubscriptions = assignPartition(partition, sortedCurrentSubscriptions, currentAssignment, consumer2AllPotentialPartitions, currentPartitionConsumer)
+	}
+
+	// narrow down the reassignment scope to only those partitions that can actually be reassigned
+	for partition := range partition2AllPotentialConsumers {
+		if !canParticipateInReassignment(partition, partition2AllPotentialConsumers) {
+			sortedPartitions = removeTopicPartitionFromMemberAssignments(sortedPartitions, partition)
+		}
+	}
+
+	// narrow down the reassignment scope to only those consumers that are subject to reassignment
+	fixedAssignments := make(map[string][]topicPartitionAssignment)
+	for memberID := range consumer2AllPotentialPartitions {
+		if !canConsumerParticipateInReassignment(memberID, currentAssignment, consumer2AllPotentialPartitions, partition2AllPotentialConsumers) {
+			sortedCurrentSubscriptions = removeValueFromSlice(sortedCurrentSubscriptions, memberID)
+			fixedAssignments[memberID] = currentAssignment[memberID]
+			delete(currentAssignment, memberID)
+		}
+	}
+
+	// create a deep copy of the current assignment so we can revert to it if we do not get a more balanced assignment later
+	preBalanceAssignment := deepCopyAssignment(currentAssignment)
+	preBalancePartitionConsumers := make(map[topicPartitionAssignment]string)
+	for k, v := range currentPartitionConsumer {
+		preBalancePartitionConsumers[k] = v
+	}
+
+	reassignmentPerformed := performReassignments(movements, sortedPartitions, currentAssignment, prevAssignment, sortedCurrentSubscriptions, consumer2AllPotentialPartitions, partition2AllPotentialConsumers, currentPartitionConsumer)
+
+	// if we are not preserving existing assignments and we have made changes to the current assignment
+	// make sure we are getting a more balanced assignment; otherwise, revert to previous assignment
+	if !initializing && reassignmentPerformed && getBalanceScore(currentAssignment) >= getBalanceScore(preBalanceAssignment) {
+		currentAssignment = deepCopyAssignment(preBalanceAssignment)
+		currentPartitionConsumer = make(map[topicPartitionAssignment]string)
+		for k, v := range preBalancePartitionConsumers {
+			currentPartitionConsumer[k] = v
+		}
+	}
+
+	// add the fixed assignments (those that could not change) back
+	for consumer, assignments := range fixedAssignments {
+		currentAssignment[consumer] = assignments
+		sortedCurrentSubscriptions = append(sortedCurrentSubscriptions, consumer)
+	}
+}
+
+// Calculate the balance score of the given assignment, as the sum of assigned partitions size difference of all consumer pairs.
+// A perfectly balanced assignment (with all consumers getting the same number of partitions) has a balance score of 0.
+// Lower balance score indicates a more balanced assignment.
+func getBalanceScore(assignment map[string][]topicPartitionAssignment) int {
+	consumer2AssignmentSize := make(map[string]int)
+	for memberID, partitions := range assignment {
+		consumer2AssignmentSize[memberID] = len(partitions)
+	}
+
+	var score float64
+	for memberID, consumerAssignmentSize := range consumer2AssignmentSize {
+		delete(consumer2AssignmentSize, memberID)
+		for _, otherConsumerAssignmentSize := range consumer2AssignmentSize {
+			score += math.Abs(float64(consumerAssignmentSize - otherConsumerAssignmentSize))
+		}
+	}
+	return int(score)
+}
+
+func isBalanced(currentAssignment map[string][]topicPartitionAssignment, sortedCurrentSubscriptions []string, allSubscriptions map[string][]topicPartitionAssignment) bool {
+	min := len(currentAssignment[sortedCurrentSubscriptions[len(sortedCurrentSubscriptions)-1]])
+	max := len(currentAssignment[sortedCurrentSubscriptions[0]])
+	if min >= max-1 {
+		// if minimum and maximum numbers of partitions assigned to consumers differ by at most one return true
+		return true
+	}
+
+	// create a mapping from partitions to the consumer assigned to them
+	allPartitions := make(map[topicPartitionAssignment]string)
+	for memberID, partitions := range currentAssignment {
+		for _, partition := range partitions {
+			if _, exists := allPartitions[partition]; exists {
+				Logger.Printf("Topic %s Partition %d is assigned more than one consumer", partition.Topic, partition.Partition)
+			}
+			allPartitions[partition] = memberID
+		}
+	}
+
+	// for each consumer that does not have all the topic partitions it can get make sure none of the topic partitions it
+	// could but did not get cannot be moved to it (because that would break the balance)
+	for _, memberID := range sortedCurrentSubscriptions {
+		consumerPartitions := currentAssignment[memberID]
+		consumerPartitionCount := len(consumerPartitions)
+
+		// skip if this consumer already has all the topic partitions it can get
+		if consumerPartitionCount == len(allSubscriptions[memberID]) {
+			continue
+		}
+
+		// otherwise make sure it cannot get any more
+		potentialTopicPartitions := allSubscriptions[memberID]
+		for _, partition := range potentialTopicPartitions {
+			if !memberAssignmentsIncludeTopicPartition(currentAssignment[memberID], partition) {
+				otherConsumer := allPartitions[partition]
+				otherConsumerPartitionCount := len(currentAssignment[otherConsumer])
+				if consumerPartitionCount < otherConsumerPartitionCount {
+					Logger.Printf("Topic %s Partition %d can be moved from consumer %s to consumer %s for a more balanced assignment", partition.Topic, partition.Partition, otherConsumer, memberID)
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+func performReassignments(movements partitionMovements, reassignablePartitions []topicPartitionAssignment, currentAssignment map[string][]topicPartitionAssignment, prevAssignment map[topicPartitionAssignment]consumerGenerationPair, sortedCurrentSubscriptions []string, consumer2AllPotentialPartitions map[string][]topicPartitionAssignment, partition2AllPotentialConsumers map[topicPartitionAssignment][]string, currentPartitionConsumer map[topicPartitionAssignment]string) bool {
+	reassignmentPerformed := false
+	modified := false
+
+	// repeat reassignment until no partition can be moved to improve the balance
+	for {
+		modified = false
+		// reassign all reassignable partitions (starting from the partition with least potential consumers and if needed)
+		// until the full list is processed or a balance is achieved
+		for _, partition := range reassignablePartitions {
+			if !isBalanced(currentAssignment, sortedCurrentSubscriptions, consumer2AllPotentialPartitions) {
+				break
+			}
+
+			// the partition must have at least two consumers
+			if len(partition2AllPotentialConsumers[partition]) <= 1 {
+				Logger.Printf("Expected more than one potential consumer for partition %s topic %d", partition.Topic, partition.Partition)
+			}
+
+			// the partition must have a consumer
+			consumer := currentPartitionConsumer[partition]
+			if consumer == "" {
+				Logger.Printf("Expected topic %s partition %d to be assigned to a consumer", partition.Topic, partition.Partition)
+			}
+
+			if _, exists := prevAssignment[partition]; exists {
+				if len(currentAssignment[consumer]) > (len(currentAssignment[prevAssignment[partition].MemberID]) + 1) {
+					sortedCurrentSubscriptions = reassignPartition(movements, partition, currentAssignment, sortedCurrentSubscriptions, currentPartitionConsumer, prevAssignment[partition].MemberID)
+					reassignmentPerformed = true
+					modified = true
+					continue
+				}
+			}
+
+			// check if a better-suited consumer exists for the partition; if so, reassign it
+			for _, otherConsumer := range partition2AllPotentialConsumers[partition] {
+				if len(currentAssignment[consumer]) > (len(currentAssignment[otherConsumer]) + 1) {
+					sortedCurrentSubscriptions = reassignPartitionToNewConsumer(movements, partition, currentAssignment, sortedCurrentSubscriptions, currentPartitionConsumer, consumer2AllPotentialPartitions)
+					reassignmentPerformed = true
+					modified = true
+					break
+				}
+
+			}
+		}
+		if !modified {
+			return reassignmentPerformed
+		}
+	}
+}
+
+func reassignPartitionToNewConsumer(movements partitionMovements, partition topicPartitionAssignment, currentAssignment map[string][]topicPartitionAssignment, sortedCurrentSubscriptions []string, currentPartitionConsumer map[topicPartitionAssignment]string, consumer2AllPotentialPartitions map[string][]topicPartitionAssignment) []string {
+	// find the new cosnumer
+	for _, anotherConsumer := range sortedCurrentSubscriptions {
+		if memberAssignmentsIncludeTopicPartition(consumer2AllPotentialPartitions[anotherConsumer], partition) {
+			return reassignPartition(movements, partition, currentAssignment, sortedCurrentSubscriptions, currentPartitionConsumer, anotherConsumer)
+		}
+	}
+	return sortedCurrentSubscriptions
+}
+
+func reassignPartition(movements partitionMovements, partition topicPartitionAssignment, currentAssignment map[string][]topicPartitionAssignment, sortedCurrentSubscriptions []string, currentPartitionConsumer map[topicPartitionAssignment]string, newConsumer string) []string {
+	consumer := currentPartitionConsumer[partition]
+	// find the correct partition movement considering the stickiness requirement
+	partitionToBeMoved := movements.getTheActualPartitionToBeMoved(partition, consumer, newConsumer)
+	sortedCurrentSubscriptions = processPartitionMovement(movements, partitionToBeMoved, newConsumer, currentAssignment, sortedCurrentSubscriptions, currentPartitionConsumer)
+	return sortedCurrentSubscriptions
+}
+
+func processPartitionMovement(movements partitionMovements, partition topicPartitionAssignment, newConsumer string, currentAssignment map[string][]topicPartitionAssignment, sortedCurrentSubscriptions []string, currentPartitionConsumer map[topicPartitionAssignment]string) []string {
+	oldConsumer := currentPartitionConsumer[partition]
+	sortedCurrentSubscriptions = removeValueFromSlice(sortedCurrentSubscriptions, oldConsumer)
+	sortedCurrentSubscriptions = removeValueFromSlice(sortedCurrentSubscriptions, newConsumer)
+
+	movements.movePartition(partition, oldConsumer, newConsumer)
+
+	currentAssignment[oldConsumer] = removeTopicPartitionFromMemberAssignments(currentAssignment[oldConsumer], partition)
+	currentAssignment[newConsumer] = append(currentAssignment[newConsumer], partition)
+	currentPartitionConsumer[partition] = newConsumer
+	sortedCurrentSubscriptions = append(sortedCurrentSubscriptions, newConsumer, oldConsumer)
+	return sortedCurrentSubscriptions
+}
+
+func canConsumerParticipateInReassignment(memberID string, currentAssignment map[string][]topicPartitionAssignment, consumer2AllPotentialPartitions map[string][]topicPartitionAssignment, partition2AllPotentialConsumers map[topicPartitionAssignment][]string) bool {
+	currentPartitions := currentAssignment[memberID]
+	currentAssignmentSize := len(currentPartitions)
+	maxAssignmentSize := len(consumer2AllPotentialPartitions[memberID])
+	if currentAssignmentSize > maxAssignmentSize {
+		Logger.Printf("The consumer %s is assigned more partitions than the maximum possible", memberID)
+	}
+	if currentAssignmentSize < maxAssignmentSize {
+		// if a consumer is not assigned all its potential partitions it is subject to reassignment
+		return true
+	}
+	for _, partition := range currentPartitions {
+		if canParticipateInReassignment(partition, partition2AllPotentialConsumers) {
+			return true
+		}
+	}
+	return false
+}
+
+func canParticipateInReassignment(partition topicPartitionAssignment, partition2AllPotentialConsumers map[topicPartitionAssignment][]string) bool {
+	if len(partition2AllPotentialConsumers[partition]) >= 2 {
+		return true
+	}
+	return false
+}
+
+// The assignment should improve the overall balance of the partition assignments to consumers.
+func assignPartition(partition topicPartitionAssignment, sortedCurrentSubscriptions []string, currentAssignment map[string][]topicPartitionAssignment, consumer2AllPotentialPartitions map[string][]topicPartitionAssignment, currentPartitionConsumer map[topicPartitionAssignment]string) []string {
+	updatedSubscriptions := make([]string, len(sortedCurrentSubscriptions))
+	for i, s := range sortedCurrentSubscriptions {
+		updatedSubscriptions[i] = s
+	}
+	for i, memberID := range sortedCurrentSubscriptions {
+		if memberAssignmentsIncludeTopicPartition(consumer2AllPotentialPartitions[memberID], partition) {
+			updatedSubscriptions = removeIndexFromSlice(updatedSubscriptions, i)
+			currentAssignment[memberID] = append(currentAssignment[memberID], partition)
+			currentPartitionConsumer[partition] = memberID
+			updatedSubscriptions = append(updatedSubscriptions, memberID)
+		}
+	}
+	return updatedSubscriptions
+}
+
+func deserializeTopicPartitionAssignment(userDataBytes []byte) (StickyAssignorUserData, error) {
+	userDataV1 := &StickyAssignorUserDataV1{}
+	if err := decode(userDataBytes, userDataV1); err != nil {
+		userDataV0 := &StickyAssignorUserDataV0{}
+		if err := decode(userDataBytes, userDataV0); err != nil {
+			return nil, err
+		}
+		return userDataV0, nil
+	}
+	return userDataV1, nil
+}
+
+// filterAssignedPartitions returns a map of consumer group members to their list of previously-assigned topic partitions, limited
+// to those topic partitions currently reported by the Kafka cluster.
+func filterAssignedPartitions(currentAssignment map[string][]topicPartitionAssignment, partition2AllPotentialConsumers map[topicPartitionAssignment][]string) map[string][]topicPartitionAssignment {
+	assignments := deepCopyAssignment(currentAssignment)
+	for memberID, partitions := range assignments {
+		// perform in-place filtering
+		i := 0
+		for _, partition := range partitions {
+			if _, exists := partition2AllPotentialConsumers[partition]; exists {
+				partitions[i] = partition
+				i++
+			}
+		}
+		assignments[memberID] = partitions[:i]
+	}
+	return assignments
+}
+
+func removeValueFromSlice(s []string, e string) []string {
+	for i, v := range s {
+		if v == e {
+			s = append(s[:i], s[i+1:]...)
+			break
+		}
+	}
+	return s
+}
+
+func removeIndexFromSlice(s []string, i int) []string {
+	if len(s) == 0 {
+		return s
+	}
+	return append(s[:i], s[i+1:]...)
+}
+
+func removeIndexFromPartitionSlice(s []topicPartitionAssignment, i int) []topicPartitionAssignment {
+	if len(s) == 0 {
+		return s
+	}
+	return append(s[:i], s[i+1:]...)
+}
+
+func removeTopicPartitionFromMemberAssignments(assignments []topicPartitionAssignment, topic topicPartitionAssignment) []topicPartitionAssignment {
+	for i, assignment := range assignments {
+		if assignment == topic {
+			assignments = append(assignments[:i], assignments[i+1:]...)
+			break
+		}
+	}
+	return assignments
+}
+
+func memberAssignmentsIncludeTopicPartition(assignments []topicPartitionAssignment, topic topicPartitionAssignment) bool {
+	for _, assignment := range assignments {
+		if assignment == topic {
+			return true
+		}
+	}
+	return false
+}
+
+func sortPartitions(currentAssignment map[string][]topicPartitionAssignment, partitionsWithADifferentPreviousAssignment map[topicPartitionAssignment]consumerGenerationPair, isFreshAssignment bool, partition2AllPotentialConsumers map[topicPartitionAssignment][]string, consumer2AllPotentialPartitions map[string][]topicPartitionAssignment) []topicPartitionAssignment {
+	sortedPartitions := make([]topicPartitionAssignment, 0)
+	if !isFreshAssignment && areSubscriptionsIdentical(partition2AllPotentialConsumers, consumer2AllPotentialPartitions) {
+		// if this is a reassignment and the subscriptions are identical (all consumers can consumer from all topics)
+		// then we just need to simply list partitions in a round robin fashion (from consumers with
+		// most assigned partitions to those with least)
+		assignments := filterAssignedPartitions(currentAssignment, partition2AllPotentialConsumers)
+
+		// sortedMemberIDs contains a descending-sorted list of consumers based on how many valid partitions are currently assigned to them
+		sortedMemberIDs := sortMemberIDsByPartitionAssignments(assignments)
+		for {
+			// loop until no consumer-group members remain
+			if len(sortedMemberIDs) == 0 {
+				break
+			}
+			for i, memberID := range sortedMemberIDs {
+				// remove member from list
+				sortedMemberIDs = removeIndexFromSlice(sortedMemberIDs, i)
+
+				// partitions that were assigned to a different consumer last time
+				prevPartitions := make([]topicPartitionAssignment, 0)
+				for partition := range partitionsWithADifferentPreviousAssignment {
+					// from partitions that had a different consumer before, keep only those that are assigned to this consumer now
+					if memberAssignmentsIncludeTopicPartition(assignments[memberID], partition) {
+						prevPartitions = append(prevPartitions, partition)
+					}
+				}
+
+				if len(prevPartitions) > 0 {
+					// if there is a partition of this consumer that was assigned to another consumer before mark it as good options for reassignment
+					partition := prevPartitions[0]
+					prevPartitions = append(prevPartitions[:0], prevPartitions[1:]...)
+					assignments[memberID] = removeTopicPartitionFromMemberAssignments(assignments[memberID], partition)
+					sortedPartitions = append(sortedPartitions, partition)
+					sortedMemberIDs = append(sortedMemberIDs, memberID)
+				} else if len(assignments[memberID]) > 0 {
+					// otherwise, mark any other one of the current partitions as a reassignment candidate
+					partition := assignments[memberID][0]
+					assignments[memberID] = append(assignments[memberID][:0], assignments[memberID][1:]...)
+					sortedPartitions = append(sortedPartitions, partition)
+					sortedMemberIDs = append(sortedMemberIDs, memberID)
+				}
+			}
+		}
+
+		for partition := range partition2AllPotentialConsumers {
+			var found bool
+			for _, p := range sortedPartitions {
+				if partition == p {
+					found = true
+					break
+				}
+			}
+			if !found {
+				sortedPartitions = append(sortedPartitions, partition)
+			}
+		}
+	} else {
+		// an ascending sorted set of topic partitions based on how many consumers can potentially use them
+		sortedPartitions = sortPartitionsByPotentialConsumerAssignments(partition2AllPotentialConsumers)
+	}
+	return sortedPartitions
+}
+
+func sortMemberIDsByPartitionAssignments(assignments map[string][]topicPartitionAssignment) []string {
+	// sort the members by the number of partition assignments in descending order
+	sortedMemberIDs := make([]string, 0, len(assignments))
+	for memberID := range assignments {
+		sortedMemberIDs = append(sortedMemberIDs, memberID)
+	}
+	sort.SliceStable(sortedMemberIDs, func(i, j int) bool {
+		return len(assignments[sortedMemberIDs[i]]) > len(assignments[sortedMemberIDs[j]])
+	})
+	return sortedMemberIDs
+}
+
+func sortPartitionsByPotentialConsumerAssignments(partition2AllPotentialConsumers map[topicPartitionAssignment][]string) []topicPartitionAssignment {
+	// sort the members by the number of partition assignments in descending order
+	sortedPartionIDs := make([]topicPartitionAssignment, 0, len(partition2AllPotentialConsumers))
+	for partition := range partition2AllPotentialConsumers {
+		sortedPartionIDs = append(sortedPartionIDs, partition)
+	}
+	sort.SliceStable(sortedPartionIDs, func(i, j int) bool {
+		return len(partition2AllPotentialConsumers[sortedPartionIDs[i]]) > len(partition2AllPotentialConsumers[sortedPartionIDs[j]])
+	})
+	return sortedPartionIDs
+}
+
+func deepCopyPartitions(src []topicPartitionAssignment) []topicPartitionAssignment {
+	dst := make([]topicPartitionAssignment, len(src))
+	for _, partition := range src {
+		dst = append(dst, partition)
+	}
+	return dst
+}
+
+func deepCopyAssignment(assignment map[string][]topicPartitionAssignment) map[string][]topicPartitionAssignment {
+	copy := make(map[string][]topicPartitionAssignment)
+	for memberID, subscriptions := range assignment {
+		copy[memberID] = append(subscriptions[:0:0], subscriptions...)
+	}
+	return copy
+}
+
+func areSubscriptionsIdentical(partition2AllPotentialConsumers map[topicPartitionAssignment][]string, consumer2AllPotentialPartitions map[string][]topicPartitionAssignment) bool {
+	curMembers := make(map[string]int)
+	for _, cur := range partition2AllPotentialConsumers {
+		if len(curMembers) == 0 {
+			for _, curMembersElem := range cur {
+				curMembers[curMembersElem]++
+			}
+			continue
+		}
+
+		if len(curMembers) != len(cur) {
+			return false
+		}
+
+		yMap := make(map[string]int)
+		for _, yElem := range cur {
+			yMap[yElem]++
+		}
+
+		for curMembersMapKey, curMembersMapVal := range curMembers {
+			if yMap[curMembersMapKey] != curMembersMapVal {
+				return false
+			}
+		}
+	}
+
+	curPartitions := make(map[topicPartitionAssignment]int)
+	for _, cur := range consumer2AllPotentialPartitions {
+		if len(curPartitions) == 0 {
+			for _, curPartitionElem := range cur {
+				curPartitions[curPartitionElem]++
+			}
+			continue
+		}
+
+		if len(curPartitions) != len(cur) {
+			return false
+		}
+
+		yMap := make(map[topicPartitionAssignment]int)
+		for _, yElem := range cur {
+			yMap[yElem]++
+		}
+
+		for curMembersMapKey, curMembersMapVal := range curPartitions {
+			if yMap[curMembersMapKey] != curMembersMapVal {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// We need to process subscriptions' user data with each consumer's reported generation in mind
+// higher generations overwrite lower generations in case of a conflict
+// note that a conflict could exist only if user data is for different generations
+func prepopulateCurrentAssignments(members map[string]ConsumerGroupMemberMetadata) (map[string][]topicPartitionAssignment, map[topicPartitionAssignment]consumerGenerationPair, error) {
+	currentAssignment := map[string][]topicPartitionAssignment{}
+	prevAssignment := map[topicPartitionAssignment]consumerGenerationPair{}
+
+	// for each partition we create a sorted map of its consumers by generation
+	sortedPartitionConsumersByGeneration := make(map[topicPartitionAssignment]map[int]string, 0)
+	for memberID, meta := range members {
+		consumerUserData, err := deserializeTopicPartitionAssignment(meta.UserData)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, partition := range consumerUserData.partitions() {
+			if consumers, exists := sortedPartitionConsumersByGeneration[partition]; exists {
+				if consumerUserData.hasGeneration() {
+					if _, generationExists := consumers[consumerUserData.generation()]; generationExists {
+						// same partition is assigned to two consumers during the same rebalance.
+						// log a warning and skip this record
+						Logger.Printf("Topic %s Partition %d is assigned to multiple consumers following sticky assignment generation %d", partition.Topic, partition.Partition, consumerUserData.generation())
+						continue
+					} else {
+						consumers[consumerUserData.generation()] = memberID
+					}
+				} else {
+					consumers[DefaultGeneration] = memberID
+				}
+			} else {
+				generation := DefaultGeneration
+				if consumerUserData.hasGeneration() {
+					generation = consumerUserData.generation()
+				}
+				sortedPartitionConsumersByGeneration[partition] = map[int]string{generation: memberID}
+			}
+		}
+	}
+
+	// prevAssignment holds the prior ConsumerGenerationPair (before current) of each partition
+	// current and previous consumers are the last two consumers of each partition in the above sorted map
+	for partition, consumers := range sortedPartitionConsumersByGeneration {
+		// sort consumers by generation in decreasing order
+		var generations []int
+		for generation := range consumers {
+			generations = append(generations, generation)
+		}
+		sort.Sort(sort.Reverse(sort.IntSlice(generations)))
+
+		if len(generations) > 0 {
+			consumer := consumers[generations[0]]
+			currentConsumerAssignments, exists := currentAssignment[consumer]
+			if !exists {
+				currentConsumerAssignments = []topicPartitionAssignment{partition}
+			} else {
+				currentConsumerAssignments = append(currentConsumerAssignments, partition)
+			}
+			currentAssignment[consumer] = currentConsumerAssignments
+
+			// check for previous assignment, if any
+			if len(generations) > 1 {
+				prevAssignment[partition] = consumerGenerationPair{
+					MemberID:   consumers[generations[1]],
+					Generation: generations[1],
+				}
+			}
+		}
+	}
+	return currentAssignment, prevAssignment, nil
+}
+
+type consumerGenerationPair struct {
+	MemberID   string
+	Generation int
+}
+
+// consumerPair represents a pair of Kafka consumer ids involved in a partition reassignment.
+type consumerPair struct {
+	srcMemberID string
+	dstMemberID string
+}
+
+// partitionMovements maintains some data structures to simplify lookup of partition movements among consumers.
+type partitionMovements struct {
+	partitionMovementsByTopic map[string]map[consumerPair][]topicPartitionAssignment
+	movements                 map[topicPartitionAssignment]consumerPair
+}
+
+func (p *partitionMovements) removeMovementRecordOfPartition(partition topicPartitionAssignment) consumerPair {
+	pair := p.movements[partition]
+	delete(p.movements, partition)
+
+	partitionMovementsForThisTopic := p.partitionMovementsByTopic[partition.Topic]
+	partitionMovementsForThisTopic[pair] = removeTopicPartitionFromMemberAssignments(partitionMovementsForThisTopic[pair], partition)
+	if len(partitionMovementsForThisTopic[pair]) == 0 {
+		delete(partitionMovementsForThisTopic, pair)
+	}
+	if len(p.partitionMovementsByTopic[partition.Topic]) == 0 {
+		delete(p.partitionMovementsByTopic, partition.Topic)
+	}
+	return pair
+}
+
+func (p *partitionMovements) addPartitionMovementRecord(partition topicPartitionAssignment, pair consumerPair) {
+	p.movements[partition] = pair
+	if _, exists := p.partitionMovementsByTopic[partition.Topic]; !exists {
+		p.partitionMovementsByTopic[partition.Topic] = make(map[consumerPair][]topicPartitionAssignment)
+	}
+	partitionMovementsForThisTopic := p.partitionMovementsByTopic[partition.Topic]
+	if _, exists := partitionMovementsForThisTopic[pair]; !exists {
+		partitionMovementsForThisTopic[pair] = make([]topicPartitionAssignment, 0)
+	}
+	partitionMovementsForThisTopic[pair] = append(partitionMovementsForThisTopic[pair], partition)
+}
+
+func (p *partitionMovements) movePartition(partition topicPartitionAssignment, oldConsumer, newConsumer string) {
+	pair := consumerPair{
+		srcMemberID: oldConsumer,
+		dstMemberID: newConsumer,
+	}
+	if _, exists := p.movements[partition]; exists {
+		// this partition has previously moved
+		existingPair := p.removeMovementRecordOfPartition(partition)
+		if existingPair.dstMemberID != oldConsumer {
+			Logger.Printf("Existing pair dstMemberID %s was not equal to the oldConsumer ID %s", existingPair.dstMemberID, oldConsumer)
+		}
+		if existingPair.srcMemberID != newConsumer {
+			// the partition is not moving back to its previous consume
+			p.addPartitionMovementRecord(partition, consumerPair{
+				srcMemberID: existingPair.srcMemberID,
+				dstMemberID: newConsumer,
+			})
+		}
+	} else {
+		p.addPartitionMovementRecord(partition, pair)
+	}
+}
+
+func (p *partitionMovements) getTheActualPartitionToBeMoved(partition topicPartitionAssignment, oldConsumer, newConsumer string) topicPartitionAssignment {
+	if _, exists := p.partitionMovementsByTopic[partition.Topic]; !exists {
+		return partition
+	}
+	if _, exists := p.movements[partition]; exists {
+		// this partition has previously moved
+		if oldConsumer != p.movements[partition].dstMemberID {
+			Logger.Printf("Partition movement dstMemberID %s was not equal to the oldConsumer ID %s", p.movements[partition].dstMemberID, oldConsumer)
+		}
+		oldConsumer = p.movements[partition].srcMemberID
+	}
+
+	partitionMovementsForThisTopic := p.partitionMovementsByTopic[partition.Topic]
+	reversePair := consumerPair{
+		srcMemberID: newConsumer,
+		dstMemberID: oldConsumer,
+	}
+	if _, exists := partitionMovementsForThisTopic[reversePair]; !exists {
+		return partition
+	}
+	return partitionMovementsForThisTopic[reversePair][0]
+}
+
+func (p *partitionMovements) isLinked(src, dst string, pairs []consumerPair, currentPath []string) ([]string, bool) {
+	if src == dst {
+		return currentPath, false
+	}
+	if len(pairs) == 0 {
+		return currentPath, false
+	}
+	for _, pair := range pairs {
+		if src == pair.srcMemberID && dst == pair.dstMemberID {
+			currentPath = append(currentPath, src, dst)
+			return currentPath, true
+		}
+	}
+
+	for _, pair := range pairs {
+		if pair.srcMemberID == src {
+			// create a deep copy of the pairs, excluding the current pair
+			reducedSet := make([]consumerPair, len(pairs)-1)
+			i := 0
+			for _, p := range pairs {
+				if p != pair {
+					reducedSet[i] = pair
+					i++
+				}
+			}
+
+			currentPath = append(currentPath, pair.srcMemberID)
+			return p.isLinked(pair.dstMemberID, dst, reducedSet, currentPath)
+		}
+	}
+	return currentPath, false
+}
+
+func (p *partitionMovements) in(cycle []string, cycles [][]string) bool {
+	superCycle := make([]string, len(cycle)-1)
+	for i := 0; i < len(cycle)-1; i++ {
+		superCycle[i] = cycle[i]
+	}
+	for _, c := range cycle {
+		superCycle = append(superCycle, c)
+	}
+	for _, foundCycle := range cycles {
+		if len(foundCycle) == len(cycle) && indexOfSubList(superCycle, foundCycle) != -1 {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOfSubList(source []string, target []string) int {
+	targetSize := len(target)
+	maxCandidate := len(source) - targetSize
+nextCand:
+	for candidate := 0; candidate <= maxCandidate; candidate++ {
+		j := candidate
+		for i := 0; i < targetSize; i++ {
+			if target[i] != source[j] {
+				// Element mismatch, try next cand
+				continue nextCand
+			}
+			j++
+		}
+		// All elements of candidate matched target
+		return candidate
+	}
+	return -1
+}
+
+func (p *partitionMovements) hasCycles(pairs []consumerPair) bool {
+	cycles := make([][]string, 0)
+	for _, pair := range pairs {
+		// create a deep copy of the pairs, excluding the current pair
+		reducedPairs := make([]consumerPair, len(pairs)-1)
+		i := 0
+		for _, p := range pairs {
+			if p != pair {
+				reducedPairs[i] = pair
+				i++
+			}
+		}
+		if path, linked := p.isLinked(pair.dstMemberID, pair.srcMemberID, reducedPairs, []string{pair.srcMemberID}); linked {
+			if !p.in(path, cycles) {
+				cycles = append(cycles, path)
+				log.Printf("A cycle of length %d was found: %v", len(path)-1, path)
+			}
+		}
+	}
+
+	// for now we want to make sure there is no partition movements of the same topic between a pair of consumers.
+	// the odds of finding a cycle among more than two consumers seem to be very low (according to various randomized
+	// tests with the given sticky algorithm) that it should not worth the added complexity of handling those cases.
+	for _, cycle := range cycles {
+		if len(cycle) == 3 {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *partitionMovements) isSticky() bool {
+	for topic, movements := range p.partitionMovementsByTopic {
+		movementPairs := make([]consumerPair, len(movements))
+		i := 0
+		for pair := range movements {
+			movementPairs[i] = pair
+			i++
+		}
+		if p.hasCycles(movementPairs) {
+			Logger.Printf("Stickiness is violated for topic %s", topic)
+			Logger.Printf("Partition movements for this topic occurred among the following consumer pairs: %v", movements)
+			return false
+		}
+	}
+	return true
 }

--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -199,7 +199,7 @@ func (s *stickyBalanceStrategy) Plan(members map[string]ConsumerGroupMemberMetad
 	}
 
 	// a mapping of partition to current consumer
-	currentPartitionConsumer := make(map[topicPartitionAssignment]string)
+	currentPartitionConsumer := make(map[topicPartitionAssignment]string, len(currentAssignment))
 	for memberID, subscriptions := range currentAssignment {
 		for _, partition := range subscriptions {
 			currentPartitionConsumer[partition] = memberID
@@ -492,7 +492,7 @@ func assignPartition(partition topicPartitionAssignment, sortedCurrentSubscripti
 	i := 0
 	for _, memberID := range sortedCurrentSubscriptions {
 		if memberAssignmentsIncludeTopicPartition(consumer2AllPotentialPartitions[memberID], partition) {
-			updatedSubscriptions = removeIndexFromSlice(updatedSubscriptions, i)
+			updatedSubscriptions = removeIndexFromStringSlice(updatedSubscriptions, i)
 			currentAssignment[memberID] = append(currentAssignment[memberID], partition)
 			currentPartitionConsumer[partition] = memberID
 			updatedSubscriptions = append(updatedSubscriptions, memberID)
@@ -533,7 +533,7 @@ func filterAssignedPartitions(currentAssignment map[string][]topicPartitionAssig
 	return assignments
 }
 
-func removeValueFromSlice(s []string, e string) []string {
+func removeValueFromStringSlice(s []string, e string) []string {
 	for i, v := range s {
 		if v == e {
 			s = append(s[:i], s[i+1:]...)
@@ -543,7 +543,7 @@ func removeValueFromSlice(s []string, e string) []string {
 	return s
 }
 
-func removeIndexFromSlice(s []string, i int) []string {
+func removeIndexFromStringSlice(s []string, i int) []string {
 	if len(s) == 0 {
 		return s
 	}

--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -729,11 +729,11 @@ func areSubscriptionsIdentical(partition2AllPotentialConsumers map[topicPartitio
 // higher generations overwrite lower generations in case of a conflict
 // note that a conflict could exist only if user data is for different generations
 func prepopulateCurrentAssignments(members map[string]ConsumerGroupMemberMetadata) (map[string][]topicPartitionAssignment, map[topicPartitionAssignment]consumerGenerationPair, error) {
-	currentAssignment := map[string][]topicPartitionAssignment{}
-	prevAssignment := map[topicPartitionAssignment]consumerGenerationPair{}
+	currentAssignment := make(map[string][]topicPartitionAssignment)
+	prevAssignment := make(map[topicPartitionAssignment]consumerGenerationPair)
 
 	// for each partition we create a sorted map of its consumers by generation
-	sortedPartitionConsumersByGeneration := make(map[topicPartitionAssignment]map[int]string, 0)
+	sortedPartitionConsumersByGeneration := make(map[topicPartitionAssignment]map[int]string)
 	for memberID, meta := range members {
 		consumerUserData, err := deserializeTopicPartitionAssignment(meta.UserData)
 		if err != nil {

--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -1,7 +1,6 @@
 package sarama
 
 import (
-	"fmt"
 	"math"
 	"sort"
 )
@@ -421,7 +420,6 @@ func (s *stickyBalanceStrategy) performReassignments(reassignablePartitions []to
 			// check if a better-suited consumer exists for the partition; if so, reassign it
 			for _, otherConsumer := range partition2AllPotentialConsumers[partition] {
 				if len(currentAssignment[consumer]) > (len(currentAssignment[otherConsumer]) + 1) {
-					fmt.Printf("Reassigning topic %s partition %d to better-suited consumer: old=%s, new=%s\n", partition.Topic, partition.Partition, consumer, otherConsumer)
 					sortedCurrentSubscriptions = s.reassignPartitionToNewConsumer(partition, currentAssignment, sortedCurrentSubscriptions, currentPartitionConsumer, consumer2AllPotentialPartitions)
 					reassignmentPerformed = true
 					modified = true

--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -373,7 +373,6 @@ func isBalanced(currentAssignment map[string][]topicPartitionAssignment, sortedC
 				otherConsumer := allPartitions[partition]
 				otherConsumerPartitionCount := len(currentAssignment[otherConsumer])
 				if consumerPartitionCount < otherConsumerPartitionCount {
-					Logger.Printf("Topic %s Partition %d can be moved from consumer %s to consumer %s for a more balanced assignment", partition.Topic, partition.Partition, otherConsumer, memberID)
 					return false
 				}
 			}

--- a/balance_strategy_test.go
+++ b/balance_strategy_test.go
@@ -1900,7 +1900,9 @@ func BenchmarkStickAssignmentWithLargeNumberOfConsumersAndTopics(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		s.Plan(members, topics)
+		if _, err := s.Plan(members, topics); err != nil {
+			b.Errorf("Error building plan in benchmark: %v", err)
+		}
 	}
 }
 
@@ -1938,7 +1940,9 @@ func BenchmarkStickAssignmentWithLargeNumberOfConsumersAndTopicsAndExistingAssig
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		s.Plan(members, topics)
+		if _, err := s.Plan(members, topics); err != nil {
+			b.Errorf("Error building plan in benchmark: %v", err)
+		}
 	}
 }
 

--- a/balance_strategy_test.go
+++ b/balance_strategy_test.go
@@ -100,3 +100,1014 @@ func TestBalanceStrategyRoundRobin(t *testing.T) {
 		}
 	}
 }
+
+func Test_deserializeTopicPartitionAssignment(t *testing.T) {
+	type args struct {
+		userDataBytes []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    StickyAssignorUserData
+		wantErr bool
+	}{
+		{
+			name: "Nil userdata bytes",
+			args: args{},
+			want: &StickyAssignorUserDataV1{},
+		},
+		{
+			name: "Non-empty invalid userdata bytes",
+			args: args{
+				userDataBytes: []byte{
+					0x00, 0x00,
+					0x00, 0x00, 0x00, 0x01,
+					0x00, 0x03, 'f', 'o', 'o',
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Valid v0 userdata bytes",
+			args: args{
+				userDataBytes: []byte{
+					0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x74, 0x30,
+					0x33, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+					0x05,
+				},
+			},
+			want: &StickyAssignorUserDataV0{
+				Topics: map[string][]int32{"t03": {5}},
+				topicPartitions: []topicPartitionAssignment{
+					topicPartitionAssignment{
+						Topic:     "t03",
+						Partition: 5,
+					},
+				},
+			},
+		},
+		{
+			name: "Valid v1 userdata bytes",
+			args: args{
+				userDataBytes: []byte{
+					0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x74, 0x30,
+					0x36, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff, 0xff,
+					0xff,
+				},
+			},
+			want: &StickyAssignorUserDataV1{
+				Topics:     map[string][]int32{"t06": {0, 4}},
+				Generation: -1,
+				topicPartitions: []topicPartitionAssignment{
+					topicPartitionAssignment{
+						Topic:     "t06",
+						Partition: 0,
+					},
+					topicPartitionAssignment{
+						Topic:     "t06",
+						Partition: 4,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := deserializeTopicPartitionAssignment(tt.args.userDataBytes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("deserializeTopicPartitionAssignment() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("deserializeTopicPartitionAssignment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_prepopulateCurrentAssignments(t *testing.T) {
+	type args struct {
+		members map[string]ConsumerGroupMemberMetadata
+	}
+	tests := []struct {
+		name                   string
+		args                   args
+		wantCurrentAssignments map[string][]topicPartitionAssignment
+		wantPrevAssignments    map[topicPartitionAssignment]consumerGenerationPair
+		wantErr                bool
+	}{
+		{
+			name:                   "Empty map",
+			wantCurrentAssignments: map[string][]topicPartitionAssignment{},
+			wantPrevAssignments:    map[topicPartitionAssignment]consumerGenerationPair{},
+		},
+		{
+			name: "Single consumer",
+			args: args{
+				members: map[string]ConsumerGroupMemberMetadata{
+					"c01": ConsumerGroupMemberMetadata{
+						Version: 2,
+						UserData: []byte{
+							0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x74, 0x30,
+							0x36, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+							0x00, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff, 0xff,
+							0xff,
+						},
+					},
+				},
+			},
+			wantCurrentAssignments: map[string][]topicPartitionAssignment{
+				"c01": []topicPartitionAssignment{
+					topicPartitionAssignment{
+						Topic:     "t06",
+						Partition: 0,
+					},
+					topicPartitionAssignment{
+						Topic:     "t06",
+						Partition: 4,
+					},
+				},
+			},
+			wantPrevAssignments: map[topicPartitionAssignment]consumerGenerationPair{},
+		},
+		{
+			name: "Duplicate consumer assignments in metadata",
+			args: args{
+				members: map[string]ConsumerGroupMemberMetadata{
+					"c01": ConsumerGroupMemberMetadata{
+						Version: 2,
+						UserData: []byte{
+							0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x74, 0x30,
+							0x36, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+							0x00, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff, 0xff,
+							0xff,
+						},
+					},
+					"c02": ConsumerGroupMemberMetadata{
+						Version: 2,
+						UserData: []byte{
+							0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x74, 0x30,
+							0x36, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+							0x00, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff, 0xff,
+							0xff,
+						},
+					},
+				},
+			},
+			wantCurrentAssignments: map[string][]topicPartitionAssignment{
+				"c01": []topicPartitionAssignment{
+					topicPartitionAssignment{
+						Topic:     "t06",
+						Partition: 0,
+					},
+					topicPartitionAssignment{
+						Topic:     "t06",
+						Partition: 4,
+					},
+				},
+			},
+			wantPrevAssignments: map[topicPartitionAssignment]consumerGenerationPair{},
+		},
+		{
+			name: "Different generations (5, 6) of consumer assignments in metadata",
+			args: args{
+				members: map[string]ConsumerGroupMemberMetadata{
+					"c01": ConsumerGroupMemberMetadata{
+						Version: 2,
+						UserData: []byte{
+							0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x74, 0x30,
+							0x36, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+							0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+							0x05,
+						},
+					},
+					"c02": ConsumerGroupMemberMetadata{
+						Version: 2,
+						UserData: []byte{
+							0x00, 0x00, 0x00, 0x01, 0x00, 0x03, 0x74, 0x30,
+							0x36, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00,
+							0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+							0x06,
+						},
+					},
+				},
+			},
+			wantCurrentAssignments: map[string][]topicPartitionAssignment{
+				"c01": []topicPartitionAssignment{
+					topicPartitionAssignment{
+						Topic:     "t06",
+						Partition: 0,
+					},
+					topicPartitionAssignment{
+						Topic:     "t06",
+						Partition: 4,
+					},
+				},
+			},
+			wantPrevAssignments: map[topicPartitionAssignment]consumerGenerationPair{
+				topicPartitionAssignment{
+					Topic:     "t06",
+					Partition: 0,
+				}: consumerGenerationPair{
+					Generation: 5,
+					MemberID:   "c01",
+				},
+				topicPartitionAssignment{
+					Topic:     "t06",
+					Partition: 4,
+				}: consumerGenerationPair{
+					Generation: 5,
+					MemberID:   "c01",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// userData := &StickyAssignorUserDataV1{}
+			// decode(tt.args.members["c01"].UserData, userData)
+			// userData.Generation = 5
+			// packet, err := encode(userData, nil)
+			// fmt.Printf("Gen 5: %s", base64.StdEncoding.EncodeToString(packet))
+
+			// userData.Generation = 6
+			// packet, err = encode(userData, nil)
+			// fmt.Printf("Gen 6: %s", base64.StdEncoding.EncodeToString(packet))
+
+			// t.FailNow()
+
+			_, gotPrevAssignments, err := prepopulateCurrentAssignments(tt.args.members)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("prepopulateCurrentAssignments() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// if !reflect.DeepEqual(gotCurrentAssignments, tt.wantCurrentAssignments) {
+			// 	t.Errorf("deserializeTopicPartitionAssignment() currentAssignments = %v, want %v", gotCurrentAssignments, tt.wantCurrentAssignments)
+			// }
+
+			if !reflect.DeepEqual(gotPrevAssignments, tt.wantPrevAssignments) {
+				t.Errorf("deserializeTopicPartitionAssignment() prevAssignments = %v, want %v", gotPrevAssignments, tt.wantPrevAssignments)
+			}
+		})
+	}
+}
+
+func Test_areSubscriptionsIdentical(t *testing.T) {
+	type args struct {
+		partition2AllPotentialConsumers map[topicPartitionAssignment][]string
+		consumer2AllPotentialPartitions map[string][]topicPartitionAssignment
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Empty consumers and partitions",
+			args: args{
+				partition2AllPotentialConsumers: make(map[topicPartitionAssignment][]string),
+				consumer2AllPotentialPartitions: make(map[string][]topicPartitionAssignment),
+			},
+			want: true,
+		},
+		{
+			name: "Topic partitions with identical consumer entries",
+			args: args{
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1", "c2", "c3"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c1", "c2", "c3"},
+					topicPartitionAssignment{Topic: "t1", Partition: 2}: []string{"c1", "c2", "c3"},
+				},
+				consumer2AllPotentialPartitions: make(map[string][]topicPartitionAssignment),
+			},
+			want: true,
+		},
+		{
+			name: "Topic partitions with mixed up consumer entries",
+			args: args{
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1", "c2", "c3"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c2", "c3", "c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 2}: []string{"c3", "c1", "c2"},
+				},
+				consumer2AllPotentialPartitions: make(map[string][]topicPartitionAssignment),
+			},
+			want: true,
+		},
+		{
+			name: "Topic partitions with different consumer entries",
+			args: args{
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1", "c2", "c3"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c2", "c3", "c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 2}: []string{"cX", "c1", "c2"},
+				},
+				consumer2AllPotentialPartitions: make(map[string][]topicPartitionAssignment),
+			},
+			want: false,
+		},
+		{
+			name: "Topic partitions with different number of consumer entries",
+			args: args{
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1", "c2", "c3"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c2", "c3", "c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 2}: []string{"c1", "c2"},
+				},
+				consumer2AllPotentialPartitions: make(map[string][]topicPartitionAssignment),
+			},
+			want: false,
+		},
+		{
+			name: "Consumers with identical topic partitions",
+			args: args{
+				partition2AllPotentialConsumers: make(map[topicPartitionAssignment][]string),
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c3": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Consumer2 with mixed up consumer entries",
+			args: args{
+				partition2AllPotentialConsumers: make(map[topicPartitionAssignment][]string),
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}, topicPartitionAssignment{Topic: "t1", Partition: 0}},
+					"c3": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 2}, topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Consumer2 with different consumer entries",
+			args: args{
+				partition2AllPotentialConsumers: make(map[topicPartitionAssignment][]string),
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}, topicPartitionAssignment{Topic: "t1", Partition: 0}},
+					"c3": []topicPartitionAssignment{topicPartitionAssignment{Topic: "tX", Partition: 2}, topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Consumer2 with different number of consumer entries",
+			args: args{
+				partition2AllPotentialConsumers: make(map[topicPartitionAssignment][]string),
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}, topicPartitionAssignment{Topic: "t1", Partition: 0}},
+					"c3": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := areSubscriptionsIdentical(tt.args.partition2AllPotentialConsumers, tt.args.consumer2AllPotentialPartitions); got != tt.want {
+				t.Errorf("areSubscriptionsIdentical() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_sortMemberIDsByPartitionAssignments(t *testing.T) {
+	type args struct {
+		assignments map[string][]topicPartitionAssignment
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "Null assignments",
+			want: make([]string, 0),
+		},
+		{
+			name: "Single assignment",
+			args: args{
+				assignments: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+						topicPartitionAssignment{Topic: "t1", Partition: 2},
+					},
+				},
+			},
+			want: []string{"c1"},
+		},
+		{
+			name: "Multiple assignments with different partition counts",
+			args: args{
+				assignments: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+					},
+					"c2": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+						topicPartitionAssignment{Topic: "t1", Partition: 2},
+					},
+					"c3": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 3},
+						topicPartitionAssignment{Topic: "t1", Partition: 4},
+						topicPartitionAssignment{Topic: "t1", Partition: 5},
+					},
+				},
+			},
+			want: []string{"c3", "c2", "c1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sortMemberIDsByPartitionAssignments(tt.args.assignments); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("sortMemberIDsByPartitionAssignments() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_sortPartitions(t *testing.T) {
+	type args struct {
+		currentAssignment                          map[string][]topicPartitionAssignment
+		partitionsWithADifferentPreviousAssignment map[topicPartitionAssignment]consumerGenerationPair
+		isFreshAssignment                          bool
+		partition2AllPotentialConsumers            map[topicPartitionAssignment][]string
+		consumer2AllPotentialPartitions            map[string][]topicPartitionAssignment
+	}
+	tests := []struct {
+		name string
+		args args
+		want []topicPartitionAssignment
+	}{
+		{
+			name: "Empty everything",
+			want: make([]topicPartitionAssignment, 0),
+		},
+		{
+			name: "Base case",
+			args: args{
+				currentAssignment: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 1}},
+					"c3": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 2}},
+				},
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c3": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+				},
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1", "c2", "c3"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c2", "c3", "c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 2}: []string{"c3", "c1", "c2"},
+				},
+			},
+		},
+		{
+			name: "Partitions assigned to a different consumer last time",
+			args: args{
+				currentAssignment: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}},
+				},
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c3": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+				},
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1", "c2", "c3"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c2", "c3", "c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 2}: []string{"c3", "c1", "c2"},
+				},
+				partitionsWithADifferentPreviousAssignment: map[topicPartitionAssignment]consumerGenerationPair{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: consumerGenerationPair{Generation: 1, MemberID: "c2"},
+				},
+			},
+			want: []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+		},
+		{
+			name: "Partitions assigned to a different consumer last time",
+			args: args{
+				currentAssignment: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 1}},
+				},
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c3": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+				},
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1", "c2", "c3"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c2", "c3", "c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 2}: []string{"c3", "c1", "c2"},
+				},
+				partitionsWithADifferentPreviousAssignment: map[topicPartitionAssignment]consumerGenerationPair{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: consumerGenerationPair{Generation: 1, MemberID: "c2"},
+				},
+			},
+		},
+		{
+			name: "Fresh assignment",
+			args: args{
+				isFreshAssignment: true,
+				currentAssignment: map[string][]topicPartitionAssignment{},
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+					"c3": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}, topicPartitionAssignment{Topic: "t1", Partition: 1}, topicPartitionAssignment{Topic: "t1", Partition: 2}},
+				},
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1", "c2", "c3"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c2", "c3", "c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 2}: []string{"c3", "c1", "c2"},
+				},
+				partitionsWithADifferentPreviousAssignment: map[topicPartitionAssignment]consumerGenerationPair{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: consumerGenerationPair{Generation: 1, MemberID: "c2"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sortPartitions(tt.args.currentAssignment, tt.args.partitionsWithADifferentPreviousAssignment, tt.args.isFreshAssignment, tt.args.partition2AllPotentialConsumers, tt.args.consumer2AllPotentialPartitions)
+			if tt.want != nil && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("sortPartitions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_filterAssignedPartitions(t *testing.T) {
+	type args struct {
+		currentAssignment               map[string][]topicPartitionAssignment
+		partition2AllPotentialConsumers map[topicPartitionAssignment][]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string][]topicPartitionAssignment
+	}{
+		{
+			name: "All partitions accounted for",
+			args: args{
+				currentAssignment: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 1}},
+				},
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c2"},
+				},
+			},
+			want: map[string][]topicPartitionAssignment{
+				"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}},
+				"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 1}},
+			},
+		},
+		{
+			name: "One consumer using an unrecognized partition",
+			args: args{
+				currentAssignment: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 1}},
+				},
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1"},
+				},
+			},
+			want: map[string][]topicPartitionAssignment{
+				"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}},
+				"c2": []topicPartitionAssignment{},
+			},
+		},
+		{
+			name: "Interleaved consumer removal",
+			args: args{
+				currentAssignment: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}},
+					"c2": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 1}},
+					"c3": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 2}},
+				},
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 2}: []string{"c3"},
+				},
+			},
+			want: map[string][]topicPartitionAssignment{
+				"c1": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 0}},
+				"c2": []topicPartitionAssignment{},
+				"c3": []topicPartitionAssignment{topicPartitionAssignment{Topic: "t1", Partition: 2}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filterAssignedPartitions(tt.args.currentAssignment, tt.args.partition2AllPotentialConsumers); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterAssignedPartitions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_removeIndexFromSlice(t *testing.T) {
+	type args struct {
+		s []string
+		i int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "Empty slice",
+			args: args{
+				s: make([]string, 0),
+				i: 0,
+			},
+			want: make([]string, 0),
+		},
+		{
+			name: "Slice with single entry",
+			args: args{
+				s: []string{"foo"},
+				i: 0,
+			},
+			want: make([]string, 0),
+		},
+		{
+			name: "Slice with multiple entries",
+			args: args{
+				s: []string{"a", "b", "c"},
+				i: 0,
+			},
+			want: []string{"b", "c"},
+		},
+		{
+			name: "Slice with multiple entries and index is in the middle",
+			args: args{
+				s: []string{"a", "b", "c"},
+				i: 1,
+			},
+			want: []string{"a", "c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeIndexFromSlice(tt.args.s, tt.args.i); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removeIndexFromSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_removeTopicPartitionFromMemberAssignments(t *testing.T) {
+	type args struct {
+		assignments []topicPartitionAssignment
+		topic       topicPartitionAssignment
+	}
+	tests := []struct {
+		name string
+		args args
+		want []topicPartitionAssignment
+	}{
+		{
+			name: "Empty",
+			args: args{
+				assignments: make([]topicPartitionAssignment, 0),
+				topic:       topicPartitionAssignment{Topic: "t1", Partition: 0},
+			},
+			want: make([]topicPartitionAssignment, 0),
+		},
+		{
+			name: "Remove first entry",
+			args: args{
+				assignments: []topicPartitionAssignment{
+					topicPartitionAssignment{Topic: "t1", Partition: 0},
+					topicPartitionAssignment{Topic: "t1", Partition: 1},
+					topicPartitionAssignment{Topic: "t1", Partition: 2},
+				},
+				topic: topicPartitionAssignment{Topic: "t1", Partition: 0},
+			},
+			want: []topicPartitionAssignment{
+				topicPartitionAssignment{Topic: "t1", Partition: 1},
+				topicPartitionAssignment{Topic: "t1", Partition: 2},
+			},
+		},
+		{
+			name: "Remove middle entry",
+			args: args{
+				assignments: []topicPartitionAssignment{
+					topicPartitionAssignment{Topic: "t1", Partition: 0},
+					topicPartitionAssignment{Topic: "t1", Partition: 1},
+					topicPartitionAssignment{Topic: "t1", Partition: 2},
+				},
+				topic: topicPartitionAssignment{Topic: "t1", Partition: 1},
+			},
+			want: []topicPartitionAssignment{
+				topicPartitionAssignment{Topic: "t1", Partition: 0},
+				topicPartitionAssignment{Topic: "t1", Partition: 2},
+			},
+		},
+		{
+			name: "Remove last entry",
+			args: args{
+				assignments: []topicPartitionAssignment{
+					topicPartitionAssignment{Topic: "t1", Partition: 0},
+					topicPartitionAssignment{Topic: "t1", Partition: 1},
+					topicPartitionAssignment{Topic: "t1", Partition: 2},
+				},
+				topic: topicPartitionAssignment{Topic: "t1", Partition: 2},
+			},
+			want: []topicPartitionAssignment{
+				topicPartitionAssignment{Topic: "t1", Partition: 0},
+				topicPartitionAssignment{Topic: "t1", Partition: 1},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeTopicPartitionFromMemberAssignments(tt.args.assignments, tt.args.topic); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removeTopicPartitionFromMemberAssignments() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_canConsumerParticipateInReassignment(t *testing.T) {
+	type args struct {
+		memberID                        string
+		currentAssignment               map[string][]topicPartitionAssignment
+		consumer2AllPotentialPartitions map[string][]topicPartitionAssignment
+		partition2AllPotentialConsumers map[topicPartitionAssignment][]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Consumer has been assigned partitions not available to it",
+			args: args{
+				memberID: "c1",
+				currentAssignment: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+						topicPartitionAssignment{Topic: "t1", Partition: 2},
+					},
+					"c2": []topicPartitionAssignment{},
+				},
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+					},
+					"c2": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+						topicPartitionAssignment{Topic: "t1", Partition: 2},
+					},
+				},
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1", "c2"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c1", "c2"},
+					topicPartitionAssignment{Topic: "t1", Partition: 2}: []string{"c2"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Consumer has been assigned all available partitions",
+			args: args{
+				memberID: "c1",
+				currentAssignment: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+					},
+				},
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+					},
+				},
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c1"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Consumer has not been assigned all available partitions",
+			args: args{
+				memberID: "c1",
+				currentAssignment: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+					},
+				},
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+						topicPartitionAssignment{Topic: "t1", Partition: 2},
+					},
+				},
+				partition2AllPotentialConsumers: map[topicPartitionAssignment][]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: []string{"c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: []string{"c1"},
+					topicPartitionAssignment{Topic: "t1", Partition: 2}: []string{"c1"},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := canConsumerParticipateInReassignment(tt.args.memberID, tt.args.currentAssignment, tt.args.consumer2AllPotentialPartitions, tt.args.partition2AllPotentialConsumers); got != tt.want {
+				t.Errorf("canConsumerParticipateInReassignment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_removeValueFromSlice(t *testing.T) {
+	type args struct {
+		s []string
+		e string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "Empty input slice",
+			args: args{
+				s: []string{},
+				e: "",
+			},
+			want: []string{},
+		},
+		{
+			name: "Input slice with one entry that doesn't match",
+			args: args{
+				s: []string{"a"},
+				e: "b",
+			},
+			want: []string{"a"},
+		},
+		{
+			name: "Input slice with multiple entries and a positive match",
+			args: args{
+				s: []string{"a", "b", "c"},
+				e: "b",
+			},
+			want: []string{"a", "c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeValueFromSlice(tt.args.s, tt.args.e); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removeValueFromSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_assignPartition(t *testing.T) {
+	type args struct {
+		partition                       topicPartitionAssignment
+		sortedCurrentSubscriptions      []string
+		currentAssignment               map[string][]topicPartitionAssignment
+		consumer2AllPotentialPartitions map[string][]topicPartitionAssignment
+		currentPartitionConsumer        map[topicPartitionAssignment]string
+	}
+	tests := []struct {
+		name                         string
+		args                         args
+		want                         []string
+		wantCurrentAssignment        map[string][]topicPartitionAssignment
+		wantCurrentPartitionConsumer map[topicPartitionAssignment]string
+	}{
+		{
+			name: "Base",
+			args: args{
+				partition:                  topicPartitionAssignment{Topic: "t1", Partition: 2},
+				sortedCurrentSubscriptions: []string{"c3", "c1", "c2"},
+				currentAssignment: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+					},
+					"c2": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+					},
+					"c3": []topicPartitionAssignment{},
+				},
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+					},
+					"c2": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+					},
+					"c3": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 2},
+					},
+				},
+				currentPartitionConsumer: map[topicPartitionAssignment]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: "c1",
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: "c2",
+				},
+			},
+			want: []string{"c1", "c2", "c3"},
+			wantCurrentAssignment: map[string][]topicPartitionAssignment{
+				"c1": []topicPartitionAssignment{
+					topicPartitionAssignment{Topic: "t1", Partition: 0},
+				},
+				"c2": []topicPartitionAssignment{
+					topicPartitionAssignment{Topic: "t1", Partition: 1},
+				},
+				"c3": []topicPartitionAssignment{
+					topicPartitionAssignment{Topic: "t1", Partition: 2},
+				},
+			},
+			wantCurrentPartitionConsumer: map[topicPartitionAssignment]string{
+				topicPartitionAssignment{Topic: "t1", Partition: 0}: "c1",
+				topicPartitionAssignment{Topic: "t1", Partition: 1}: "c2",
+				topicPartitionAssignment{Topic: "t1", Partition: 2}: "c3",
+			},
+		},
+		{
+			name: "Unassignable Partition",
+			args: args{
+				partition:                  topicPartitionAssignment{Topic: "t1", Partition: 3},
+				sortedCurrentSubscriptions: []string{"c3", "c1", "c2"},
+				currentAssignment: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+					},
+					"c2": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+					},
+					"c3": []topicPartitionAssignment{},
+				},
+				consumer2AllPotentialPartitions: map[string][]topicPartitionAssignment{
+					"c1": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 0},
+					},
+					"c2": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 1},
+					},
+					"c3": []topicPartitionAssignment{
+						topicPartitionAssignment{Topic: "t1", Partition: 2},
+					},
+				},
+				currentPartitionConsumer: map[topicPartitionAssignment]string{
+					topicPartitionAssignment{Topic: "t1", Partition: 0}: "c1",
+					topicPartitionAssignment{Topic: "t1", Partition: 1}: "c2",
+				},
+			},
+			want: []string{"c3", "c1", "c2"},
+			wantCurrentAssignment: map[string][]topicPartitionAssignment{
+				"c1": []topicPartitionAssignment{
+					topicPartitionAssignment{Topic: "t1", Partition: 0},
+				},
+				"c2": []topicPartitionAssignment{
+					topicPartitionAssignment{Topic: "t1", Partition: 1},
+				},
+				"c3": []topicPartitionAssignment{},
+			},
+			wantCurrentPartitionConsumer: map[topicPartitionAssignment]string{
+				topicPartitionAssignment{Topic: "t1", Partition: 0}: "c1",
+				topicPartitionAssignment{Topic: "t1", Partition: 1}: "c2",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := assignPartition(tt.args.partition, tt.args.sortedCurrentSubscriptions, tt.args.currentAssignment, tt.args.consumer2AllPotentialPartitions, tt.args.currentPartitionConsumer); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("assignPartition() = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(tt.args.currentAssignment, tt.wantCurrentAssignment) {
+				t.Errorf("assignPartition() currentAssignment = %v, want %v", tt.args.currentAssignment, tt.wantCurrentAssignment)
+			}
+			if !reflect.DeepEqual(tt.args.currentPartitionConsumer, tt.wantCurrentPartitionConsumer) {
+				t.Errorf("assignPartition() currentPartitionConsumer = %v, want %v", tt.args.currentPartitionConsumer, tt.wantCurrentPartitionConsumer)
+			}
+		})
+	}
+}

--- a/balance_strategy_test.go
+++ b/balance_strategy_test.go
@@ -1278,6 +1278,27 @@ func Test_stickyBalanceStrategy_Plan(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Three consumers (two old, one new) with one topic and twelve partitions",
+			args: args{
+				members: map[string]ConsumerGroupMemberMetadata{
+					"consumer1": ConsumerGroupMemberMetadata{
+						Topics:   []string{"topic1"},
+						UserData: encodeSubscriberPlanWithGeneration(t, map[string][]int32{"topic1": []int32{4, 11, 8, 5, 9, 2}}, 1),
+					},
+					"consumer2": ConsumerGroupMemberMetadata{
+						Topics:   []string{"topic1"},
+						UserData: encodeSubscriberPlanWithGeneration(t, map[string][]int32{"topic1": []int32{1, 3, 0, 7, 10, 6}}, 1),
+					},
+					"consumer3": ConsumerGroupMemberMetadata{
+						Topics: []string{"topic1"},
+					},
+				},
+				topics: map[string][]int32{
+					"topic1": []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/balance_strategy_test.go
+++ b/balance_strategy_test.go
@@ -1360,11 +1360,11 @@ func Test_stickyBalanceStrategy_Plan_AddRemoveConsumerOneTopic(t *testing.T) {
 	}
 	plan1, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan1) {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() unbalanced")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan1)
@@ -1379,15 +1379,15 @@ func Test_stickyBalanceStrategy_Plan_AddRemoveConsumerOneTopic(t *testing.T) {
 	}
 	plan2, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() plan 2 error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan2) {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 is unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 is unbalanced")
 		return
 	}
 	if !s.movements.isSticky() {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 not sticky")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 not sticky")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan2)
@@ -1400,15 +1400,15 @@ func Test_stickyBalanceStrategy_Plan_AddRemoveConsumerOneTopic(t *testing.T) {
 	}
 	plan3, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 3 error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() plan 3 error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan3) {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 3 is unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() plan 3 is unbalanced")
 		return
 	}
 	if !s.movements.isSticky() {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 3 not sticky")
+		t.Error("stickyBalanceStrategy.Plan() plan 3 not sticky")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan3)
@@ -1443,11 +1443,11 @@ func Test_stickyBalanceStrategy_Plan_PoorRoundRobinAssignmentScenario(t *testing
 
 	plan, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan) {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() unbalanced")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan)
@@ -1470,11 +1470,11 @@ func Test_stickyBalanceStrategy_Plan_AddRemoveTopicTwoConsumers(t *testing.T) {
 	}
 	plan1, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan1) {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() unbalanced")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan1)
@@ -1492,15 +1492,15 @@ func Test_stickyBalanceStrategy_Plan_AddRemoveTopicTwoConsumers(t *testing.T) {
 
 	plan2, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() plan 2 error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan2) {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 is unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 is unbalanced")
 		return
 	}
 	if !s.movements.isSticky() {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 not sticky")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 not sticky")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan2)
@@ -1518,15 +1518,15 @@ func Test_stickyBalanceStrategy_Plan_AddRemoveTopicTwoConsumers(t *testing.T) {
 
 	plan3, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 3 error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() plan 3 error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan3) {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 3 is unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() plan 3 is unbalanced")
 		return
 	}
 	if !s.movements.isSticky() {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 3 not sticky")
+		t.Error("stickyBalanceStrategy.Plan() plan 3 not sticky")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan3)
@@ -1555,11 +1555,11 @@ func Test_stickyBalanceStrategy_Plan_ReassignmentAfterOneConsumerLeaves(t *testi
 
 	plan, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan) {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() unbalanced")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan)
@@ -1578,15 +1578,15 @@ func Test_stickyBalanceStrategy_Plan_ReassignmentAfterOneConsumerLeaves(t *testi
 
 	plan2, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() plan 2 AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() plan 2 error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan2) {
-		t.Error("stickyBalanceStrategy.Plan() plan 2 AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 unbalanced")
 		return
 	}
 	if !s.movements.isSticky() {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 not sticky")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 not sticky")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan2)
@@ -1608,11 +1608,11 @@ func Test_stickyBalanceStrategy_Plan_ReassignmentAfterOneConsumerAdded(t *testin
 
 	plan, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan) {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() unbalanced")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan)
@@ -1622,15 +1622,15 @@ func Test_stickyBalanceStrategy_Plan_ReassignmentAfterOneConsumerAdded(t *testin
 
 	plan2, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() plan 2 AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() plan 2 error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan2) {
-		t.Error("stickyBalanceStrategy.Plan() plan 2 AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 unbalanced")
 		return
 	}
 	if !s.movements.isSticky() {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 not sticky")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 not sticky")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan2)
@@ -1659,11 +1659,11 @@ func Test_stickyBalanceStrategy_Plan_SameSubscriptions(t *testing.T) {
 
 	plan, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan) {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() unbalanced")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan)
@@ -1678,15 +1678,15 @@ func Test_stickyBalanceStrategy_Plan_SameSubscriptions(t *testing.T) {
 
 	plan2, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() plan 2 AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() plan 2 error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan2) {
-		t.Error("stickyBalanceStrategy.Plan() plan 2 AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 unbalanced")
 		return
 	}
 	if !s.movements.isSticky() {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 not sticky")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 not sticky")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan2)
@@ -1717,11 +1717,11 @@ func Test_stickyBalanceStrategy_Plan_LargeAssignmentWithMultipleConsumersLeaving
 
 	plan, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan) {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() unbalanced")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan)
@@ -1738,15 +1738,15 @@ func Test_stickyBalanceStrategy_Plan_LargeAssignmentWithMultipleConsumersLeaving
 
 	plan2, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() plan 2 AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() plan 2 error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan2) {
-		t.Error("stickyBalanceStrategy.Plan() plan 2 AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 unbalanced")
 		return
 	}
 	if !s.movements.isSticky() {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 not sticky")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 not sticky")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan2)
@@ -1770,7 +1770,7 @@ func Test_stickyBalanceStrategy_Plan_NewSubscription(t *testing.T) {
 
 	plan, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() error = %v", err)
 		return
 	}
 	verifyValidityAndBalance(t, members, plan)
@@ -1779,15 +1779,15 @@ func Test_stickyBalanceStrategy_Plan_NewSubscription(t *testing.T) {
 
 	plan2, err := s.Plan(members, topics)
 	if err != nil {
-		t.Errorf("stickyBalanceStrategy.Plan() plan 2 AddRemoveConsumerOneTopic error = %v", err)
+		t.Errorf("stickyBalanceStrategy.Plan() plan 2 error = %v", err)
 		return
 	}
 	if !isFullyBalanced(plan2) {
-		t.Error("stickyBalanceStrategy.Plan() plan 2 AddRemoveConsumerOneTopic unbalanced")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 unbalanced")
 		return
 	}
 	if !s.movements.isSticky() {
-		t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 not sticky")
+		t.Error("stickyBalanceStrategy.Plan() plan 2 not sticky")
 		return
 	}
 	verifyValidityAndBalance(t, members, plan2)
@@ -1826,11 +1826,11 @@ func Test_stickyBalanceStrategy_Plan_ReassignmentWithRandomSubscriptionsAndChang
 		s := &stickyBalanceStrategy{}
 		plan, err := s.Plan(members, partitionsPerTopic)
 		if err != nil {
-			t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic error = %v", err)
+			t.Errorf("stickyBalanceStrategy.Plan() error = %v", err)
 			return
 		}
 		if !isFullyBalanced(plan) {
-			t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic unbalanced")
+			t.Error("stickyBalanceStrategy.Plan() unbalanced")
 			return
 		}
 		verifyValidityAndBalance(t, members, plan)
@@ -1847,15 +1847,15 @@ func Test_stickyBalanceStrategy_Plan_ReassignmentWithRandomSubscriptionsAndChang
 		}
 		plan2, err := s.Plan(membersPlan2, partitionsPerTopic)
 		if err != nil {
-			t.Errorf("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic error = %v", err)
+			t.Errorf("stickyBalanceStrategy.Plan() plan 2 error = %v", err)
 			return
 		}
 		if !isFullyBalanced(plan2) {
-			t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic unbalanced")
+			t.Error("stickyBalanceStrategy.Plan() plan 2 unbalanced")
 			return
 		}
 		if !s.movements.isSticky() {
-			t.Error("stickyBalanceStrategy.Plan() AddRemoveConsumerOneTopic plan 2 not sticky")
+			t.Error("stickyBalanceStrategy.Plan() plan 2 not sticky")
 			return
 		}
 		verifyValidityAndBalance(t, membersPlan2, plan2)

--- a/balance_strategy_test.go
+++ b/balance_strategy_test.go
@@ -1299,6 +1299,27 @@ func Test_stickyBalanceStrategy_Plan(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Three consumers (two old, one new) with one topic and 13 partitions",
+			args: args{
+				members: map[string]ConsumerGroupMemberMetadata{
+					"consumer1": ConsumerGroupMemberMetadata{
+						Topics:   []string{"topic1"},
+						UserData: encodeSubscriberPlanWithGeneration(t, map[string][]int32{"topic1": []int32{4, 11, 8, 5, 9, 2, 6}}, 1),
+					},
+					"consumer2": ConsumerGroupMemberMetadata{
+						Topics:   []string{"topic1"},
+						UserData: encodeSubscriberPlanWithGeneration(t, map[string][]int32{"topic1": []int32{1, 3, 0, 7, 10, 12}}, 1),
+					},
+					"consumer3": ConsumerGroupMemberMetadata{
+						Topics: []string{"topic1"},
+					},
+				},
+				topics: map[string][]int32{
+					"topic1": []int32{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/balance_strategy_test.go
+++ b/balance_strategy_test.go
@@ -330,27 +330,11 @@ func Test_prepopulateCurrentAssignments(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// userData := &StickyAssignorUserDataV1{}
-			// decode(tt.args.members["c01"].UserData, userData)
-			// userData.Generation = 5
-			// packet, err := encode(userData, nil)
-			// fmt.Printf("Gen 5: %s", base64.StdEncoding.EncodeToString(packet))
-
-			// userData.Generation = 6
-			// packet, err = encode(userData, nil)
-			// fmt.Printf("Gen 6: %s", base64.StdEncoding.EncodeToString(packet))
-
-			// t.FailNow()
-
 			_, gotPrevAssignments, err := prepopulateCurrentAssignments(tt.args.members)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("prepopulateCurrentAssignments() error = %v, wantErr %v", err, tt.wantErr)
 			}
-
-			// if !reflect.DeepEqual(gotCurrentAssignments, tt.wantCurrentAssignments) {
-			// 	t.Errorf("deserializeTopicPartitionAssignment() currentAssignments = %v, want %v", gotCurrentAssignments, tt.wantCurrentAssignments)
-			// }
 
 			if !reflect.DeepEqual(gotPrevAssignments, tt.wantPrevAssignments) {
 				t.Errorf("deserializeTopicPartitionAssignment() prevAssignments = %v, want %v", gotPrevAssignments, tt.wantPrevAssignments)

--- a/balance_strategy_test.go
+++ b/balance_strategy_test.go
@@ -706,131 +706,6 @@ func Test_filterAssignedPartitions(t *testing.T) {
 	}
 }
 
-func Test_removeIndexFromSlice(t *testing.T) {
-	type args struct {
-		s []string
-		i int
-	}
-	tests := []struct {
-		name string
-		args args
-		want []string
-	}{
-		{
-			name: "Empty slice",
-			args: args{
-				s: make([]string, 0),
-				i: 0,
-			},
-			want: make([]string, 0),
-		},
-		{
-			name: "Slice with single entry",
-			args: args{
-				s: []string{"foo"},
-				i: 0,
-			},
-			want: make([]string, 0),
-		},
-		{
-			name: "Slice with multiple entries",
-			args: args{
-				s: []string{"a", "b", "c"},
-				i: 0,
-			},
-			want: []string{"b", "c"},
-		},
-		{
-			name: "Slice with multiple entries and index is in the middle",
-			args: args{
-				s: []string{"a", "b", "c"},
-				i: 1,
-			},
-			want: []string{"a", "c"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := removeIndexFromSlice(tt.args.s, tt.args.i); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("removeIndexFromSlice() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func Test_removeTopicPartitionFromMemberAssignments(t *testing.T) {
-	type args struct {
-		assignments []topicPartitionAssignment
-		topic       topicPartitionAssignment
-	}
-	tests := []struct {
-		name string
-		args args
-		want []topicPartitionAssignment
-	}{
-		{
-			name: "Empty",
-			args: args{
-				assignments: make([]topicPartitionAssignment, 0),
-				topic:       topicPartitionAssignment{Topic: "t1", Partition: 0},
-			},
-			want: make([]topicPartitionAssignment, 0),
-		},
-		{
-			name: "Remove first entry",
-			args: args{
-				assignments: []topicPartitionAssignment{
-					topicPartitionAssignment{Topic: "t1", Partition: 0},
-					topicPartitionAssignment{Topic: "t1", Partition: 1},
-					topicPartitionAssignment{Topic: "t1", Partition: 2},
-				},
-				topic: topicPartitionAssignment{Topic: "t1", Partition: 0},
-			},
-			want: []topicPartitionAssignment{
-				topicPartitionAssignment{Topic: "t1", Partition: 1},
-				topicPartitionAssignment{Topic: "t1", Partition: 2},
-			},
-		},
-		{
-			name: "Remove middle entry",
-			args: args{
-				assignments: []topicPartitionAssignment{
-					topicPartitionAssignment{Topic: "t1", Partition: 0},
-					topicPartitionAssignment{Topic: "t1", Partition: 1},
-					topicPartitionAssignment{Topic: "t1", Partition: 2},
-				},
-				topic: topicPartitionAssignment{Topic: "t1", Partition: 1},
-			},
-			want: []topicPartitionAssignment{
-				topicPartitionAssignment{Topic: "t1", Partition: 0},
-				topicPartitionAssignment{Topic: "t1", Partition: 2},
-			},
-		},
-		{
-			name: "Remove last entry",
-			args: args{
-				assignments: []topicPartitionAssignment{
-					topicPartitionAssignment{Topic: "t1", Partition: 0},
-					topicPartitionAssignment{Topic: "t1", Partition: 1},
-					topicPartitionAssignment{Topic: "t1", Partition: 2},
-				},
-				topic: topicPartitionAssignment{Topic: "t1", Partition: 2},
-			},
-			want: []topicPartitionAssignment{
-				topicPartitionAssignment{Topic: "t1", Partition: 0},
-				topicPartitionAssignment{Topic: "t1", Partition: 1},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := removeTopicPartitionFromMemberAssignments(tt.args.assignments, tt.args.topic); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("removeTopicPartitionFromMemberAssignments() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_canConsumerParticipateInReassignment(t *testing.T) {
 	type args struct {
 		memberID                        string
@@ -932,7 +807,132 @@ func Test_canConsumerParticipateInReassignment(t *testing.T) {
 	}
 }
 
-func Test_removeValueFromSlice(t *testing.T) {
+func Test_removeTopicPartitionFromMemberAssignments(t *testing.T) {
+	type args struct {
+		assignments []topicPartitionAssignment
+		topic       topicPartitionAssignment
+	}
+	tests := []struct {
+		name string
+		args args
+		want []topicPartitionAssignment
+	}{
+		{
+			name: "Empty",
+			args: args{
+				assignments: make([]topicPartitionAssignment, 0),
+				topic:       topicPartitionAssignment{Topic: "t1", Partition: 0},
+			},
+			want: make([]topicPartitionAssignment, 0),
+		},
+		{
+			name: "Remove first entry",
+			args: args{
+				assignments: []topicPartitionAssignment{
+					topicPartitionAssignment{Topic: "t1", Partition: 0},
+					topicPartitionAssignment{Topic: "t1", Partition: 1},
+					topicPartitionAssignment{Topic: "t1", Partition: 2},
+				},
+				topic: topicPartitionAssignment{Topic: "t1", Partition: 0},
+			},
+			want: []topicPartitionAssignment{
+				topicPartitionAssignment{Topic: "t1", Partition: 1},
+				topicPartitionAssignment{Topic: "t1", Partition: 2},
+			},
+		},
+		{
+			name: "Remove middle entry",
+			args: args{
+				assignments: []topicPartitionAssignment{
+					topicPartitionAssignment{Topic: "t1", Partition: 0},
+					topicPartitionAssignment{Topic: "t1", Partition: 1},
+					topicPartitionAssignment{Topic: "t1", Partition: 2},
+				},
+				topic: topicPartitionAssignment{Topic: "t1", Partition: 1},
+			},
+			want: []topicPartitionAssignment{
+				topicPartitionAssignment{Topic: "t1", Partition: 0},
+				topicPartitionAssignment{Topic: "t1", Partition: 2},
+			},
+		},
+		{
+			name: "Remove last entry",
+			args: args{
+				assignments: []topicPartitionAssignment{
+					topicPartitionAssignment{Topic: "t1", Partition: 0},
+					topicPartitionAssignment{Topic: "t1", Partition: 1},
+					topicPartitionAssignment{Topic: "t1", Partition: 2},
+				},
+				topic: topicPartitionAssignment{Topic: "t1", Partition: 2},
+			},
+			want: []topicPartitionAssignment{
+				topicPartitionAssignment{Topic: "t1", Partition: 0},
+				topicPartitionAssignment{Topic: "t1", Partition: 1},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeTopicPartitionFromMemberAssignments(tt.args.assignments, tt.args.topic); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removeTopicPartitionFromMemberAssignments() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_removeIndexFromStringSlice(t *testing.T) {
+	type args struct {
+		s []string
+		i int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{
+			name: "Empty slice",
+			args: args{
+				s: make([]string, 0),
+				i: 0,
+			},
+			want: make([]string, 0),
+		},
+		{
+			name: "Slice with single entry",
+			args: args{
+				s: []string{"foo"},
+				i: 0,
+			},
+			want: make([]string, 0),
+		},
+		{
+			name: "Slice with multiple entries",
+			args: args{
+				s: []string{"a", "b", "c"},
+				i: 0,
+			},
+			want: []string{"b", "c"},
+		},
+		{
+			name: "Slice with multiple entries and index is in the middle",
+			args: args{
+				s: []string{"a", "b", "c"},
+				i: 1,
+			},
+			want: []string{"a", "c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeIndexFromStringSlice(tt.args.s, tt.args.i); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removeIndexFromSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_removeValueFromStringSlice(t *testing.T) {
 	type args struct {
 		s []string
 		e string
@@ -969,7 +969,7 @@ func Test_removeValueFromSlice(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := removeValueFromSlice(tt.args.s, tt.args.e); !reflect.DeepEqual(got, tt.want) {
+			if got := removeValueFromStringSlice(tt.args.s, tt.args.e); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("removeValueFromSlice() = %v, want %v", got, tt.want)
 			}
 		})

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -306,9 +306,14 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (
 		req.RebalanceTimeout = int32(c.config.Consumer.Group.Rebalance.Timeout / time.Millisecond)
 	}
 
+	// use static user-data if configured, otherwise use consumer-group userdata from the last sync
+	userData := c.config.Consumer.Group.Member.UserData
+	if len(userData) == 0 {
+		userData = c.consumerGroupUserData
+	}
 	meta := &ConsumerGroupMemberMetadata{
 		Topics:   topics,
-		UserData: c.consumerGroupUserData,
+		UserData: userData,
 	}
 	strategy := c.config.Consumer.Group.Rebalance.Strategy
 	if err := req.AddGroupProtocolMetadata(strategy.Name(), meta); err != nil {

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -63,6 +63,8 @@ type consumerGroup struct {
 	lock      sync.Mutex
 	closed    chan none
 	closeOnce sync.Once
+
+	consumerGroupUserData []byte
 }
 
 // NewConsumerGroup creates a new consumer group the given broker addresses and configuration.
@@ -282,6 +284,7 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 			return nil, err
 		}
 		claims = members.Topics
+		c.consumerGroupUserData = members.UserData
 
 		for _, partitions := range claims {
 			sort.Sort(int32Slice(partitions))
@@ -305,7 +308,7 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (
 
 	meta := &ConsumerGroupMemberMetadata{
 		Topics:   topics,
-		UserData: c.config.Consumer.Group.Member.UserData,
+		UserData: c.consumerGroupUserData,
 	}
 	strategy := c.config.Consumer.Group.Rebalance.Strategy
 	if err := req.AddGroupProtocolMetadata(strategy.Name(), meta); err != nil {

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -64,7 +64,7 @@ type consumerGroup struct {
 	closed    chan none
 	closeOnce sync.Once
 
-	consumerGroupUserData []byte
+	userData []byte
 }
 
 // NewConsumerGroup creates a new consumer group the given broker addresses and configuration.
@@ -284,7 +284,7 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 			return nil, err
 		}
 		claims = members.Topics
-		c.consumerGroupUserData = members.UserData
+		c.userData = members.UserData
 
 		for _, partitions := range claims {
 			sort.Sort(int32Slice(partitions))
@@ -309,7 +309,7 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (
 	// use static user-data if configured, otherwise use consumer-group userdata from the last sync
 	userData := c.config.Consumer.Group.Member.UserData
 	if len(userData) == 0 {
-		userData = c.consumerGroupUserData
+		userData = c.userData
 	}
 	meta := &ConsumerGroupMemberMetadata{
 		Topics:   topics,

--- a/examples/consumergroup/main.go
+++ b/examples/consumergroup/main.go
@@ -29,7 +29,7 @@ func init() {
 	flag.StringVar(&group, "group", "", "Kafka consumer group definition")
 	flag.StringVar(&version, "version", "2.1.1", "Kafka cluster version")
 	flag.StringVar(&topics, "topics", "", "Kafka topics to be consumed, as a comma seperated list")
-	flag.StringVar(&assignor, "assignor", "range", "Consumer group partition assignment strategy (range, roundbin, sticky)")
+	flag.StringVar(&assignor, "assignor", "range", "Consumer group partition assignment strategy (range, roundrobin, sticky)")
 	flag.BoolVar(&oldest, "oldest", true, "Kafka consumer consume initial ofset from oldest")
 	flag.BoolVar(&verbose, "verbose", false, "Sarama logging")
 	flag.Parse()

--- a/examples/consumergroup/main.go
+++ b/examples/consumergroup/main.go
@@ -15,12 +15,13 @@ import (
 
 // Sarma configuration options
 var (
-	brokers = ""
-	version = ""
-	group   = ""
-	topics  = ""
-	oldest  = true
-	verbose = false
+	brokers  = ""
+	version  = ""
+	group    = ""
+	topics   = ""
+	assignor = ""
+	oldest   = true
+	verbose  = false
 )
 
 func init() {
@@ -28,6 +29,7 @@ func init() {
 	flag.StringVar(&group, "group", "", "Kafka consumer group definition")
 	flag.StringVar(&version, "version", "2.1.1", "Kafka cluster version")
 	flag.StringVar(&topics, "topics", "", "Kafka topics to be consumed, as a comma seperated list")
+	flag.StringVar(&assignor, "assignor", "range", "Consumer group partition assignment strategy (range, roundbin, sticky)")
 	flag.BoolVar(&oldest, "oldest", true, "Kafka consumer consume initial ofset from oldest")
 	flag.BoolVar(&verbose, "verbose", false, "Sarama logging")
 	flag.Parse()
@@ -63,6 +65,17 @@ func main() {
 	 */
 	config := sarama.NewConfig()
 	config.Version = version
+
+	switch assignor {
+	case "sticky":
+		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategySticky
+	case "roundrobin":
+		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRoundRobin
+	case "range":
+		config.Consumer.Group.Rebalance.Strategy = sarama.BalanceStrategyRange
+	default:
+		log.Panicf("Unrecognized consumer group partition assignor: %s", assignor)
+	}
 
 	if oldest {
 		config.Consumer.Offsets.Initial = sarama.OffsetOldest

--- a/sticky_assignor_user_data.go
+++ b/sticky_assignor_user_data.go
@@ -56,7 +56,7 @@ func (m *StickyAssignorUserDataV0) decode(pd packetDecoder) (err error) {
 
 func (m *StickyAssignorUserDataV0) partitions() []topicPartitionAssignment { return m.topicPartitions }
 func (m *StickyAssignorUserDataV0) hasGeneration() bool                    { return false }
-func (m *StickyAssignorUserDataV0) generation() int                        { return -1 }
+func (m *StickyAssignorUserDataV0) generation() int                        { return defaultGeneration }
 
 //StickyAssignorUserDataV1 holds topic partition information for an assignment
 type StickyAssignorUserDataV1 struct {

--- a/sticky_assignor_user_data.go
+++ b/sticky_assignor_user_data.go
@@ -1,0 +1,93 @@
+package sarama
+
+//StickyAssignorUserDataV0 holds topic partition information for an assignment
+type StickyAssignorUserDataV0 struct {
+	Topics map[string][]int32
+}
+
+func (m *StickyAssignorUserDataV0) encode(pe packetEncoder) error {
+	if err := pe.putArrayLength(len(m.Topics)); err != nil {
+		return err
+	}
+
+	for topic, partitions := range m.Topics {
+		if err := pe.putString(topic); err != nil {
+			return err
+		}
+		if err := pe.putInt32Array(partitions); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *StickyAssignorUserDataV0) decode(pd packetDecoder) (err error) {
+	var topicLen int
+	if topicLen, err = pd.getArrayLength(); err != nil {
+		return
+	}
+
+	m.Topics = make(map[string][]int32, topicLen)
+	for i := 0; i < topicLen; i++ {
+		var topic string
+		if topic, err = pd.getString(); err != nil {
+			return
+		}
+		if m.Topics[topic], err = pd.getInt32Array(); err != nil {
+			return
+		}
+	}
+
+	return nil
+}
+
+//StickyAssignorUserDataV1 holds topic partition information for an assignment
+type StickyAssignorUserDataV1 struct {
+	Topics     map[string][]int32
+	Generation int32
+}
+
+func (m *StickyAssignorUserDataV1) encode(pe packetEncoder) error {
+	if err := pe.putArrayLength(len(m.Topics)); err != nil {
+		return err
+	}
+
+	for topic, partitions := range m.Topics {
+		if err := pe.putString(topic); err != nil {
+			return err
+		}
+		if err := pe.putInt32Array(partitions); err != nil {
+			return err
+		}
+	}
+
+	pe.putInt32(m.Generation)
+
+	return nil
+}
+
+func (m *StickyAssignorUserDataV1) decode(pd packetDecoder) (err error) {
+	var topicLen int
+	if topicLen, err = pd.getArrayLength(); err != nil {
+		return
+	}
+
+	m.Topics = make(map[string][]int32, topicLen)
+	for i := 0; i < topicLen; i++ {
+		var topic string
+		if topic, err = pd.getString(); err != nil {
+			return
+		}
+		if m.Topics[topic], err = pd.getInt32Array(); err != nil {
+			return
+		}
+	}
+
+	m.Generation, err = pd.getInt32()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sticky_assignor_user_data_test.go
+++ b/sticky_assignor_user_data_test.go
@@ -1,0 +1,51 @@
+package sarama
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestStickyAssignorUserDataV0(t *testing.T) {
+	// Single topic with deterministic ordering across encode-decode
+	req := &StickyAssignorUserDataV0{}
+	data := decodeUserDataBytes(t, "AAAAAQADdDAzAAAAAQAAAAU=")
+	testDecodable(t, "", req, data)
+	testEncodable(t, "", req, data)
+
+	// Multiple partitions
+	req = &StickyAssignorUserDataV0{}
+	data = decodeUserDataBytes(t, "AAAAAQADdDE4AAAAEgAAAAAAAAABAAAAAgAAAAMAAAAEAAAABQAAAAYAAAAHAAAACAAAAAkAAAAKAAAACwAAAAwAAAANAAAADgAAAA8AAAAQAAAAEQ==")
+	testDecodable(t, "", req, data)
+
+	// Multiple topics and partitions
+	req = &StickyAssignorUserDataV0{}
+	data = decodeUserDataBytes(t, "AAAABQADdDEyAAAAAgAAAAIAAAAKAAN0MTEAAAABAAAABAADdDE0AAAAAQAAAAgAA3QxMwAAAAEAAAANAAN0MDkAAAABAAAABQ==")
+	testDecodable(t, "", req, data)
+}
+
+func TestStickyAssignorUserDataV1(t *testing.T) {
+	// Single topic with deterministic ordering across encode-decode
+	req := &StickyAssignorUserDataV1{}
+	data := decodeUserDataBytes(t, "AAAAAQADdDA2AAAAAgAAAAAAAAAE/////w==")
+	testDecodable(t, "", req, data)
+	testEncodable(t, "", req, data)
+
+	// Multiple topics and partitions
+	req = &StickyAssignorUserDataV1{}
+	data = decodeUserDataBytes(t, "AAAABgADdDEwAAAAAgAAAAIAAAAJAAN0MTIAAAACAAAAAwAAAAsAA3QxNAAAAAEAAAAEAAN0MTMAAAABAAAACwADdDE1AAAAAQAAAAwAA3QwOQAAAAEAAAAG/////w==")
+	testDecodable(t, "", req, data)
+
+	// Generation is populated
+	req = &StickyAssignorUserDataV1{}
+	data = decodeUserDataBytes(t, "AAAAAQAHdG9waWMwMQAAAAMAAAAAAAAAAQAAAAIAAAAB")
+	testDecodable(t, "", req, data)
+}
+
+func decodeUserDataBytes(t *testing.T, base64Data string) []byte {
+	data, err := base64.StdEncoding.DecodeString(base64Data)
+	if err != nil {
+		t.Errorf("Error decoding data: %v", err)
+		t.FailNow()
+	}
+	return data
+}


### PR DESCRIPTION
Kafka Improvement (KIP) [KIP-54 ](https://cwiki.apache.org/confluence/display/KAFKA/KIP-54+-+Sticky+Partition+Assignment+Strategy) defined a sticky partition assignment strategy. This differs from the range and roundrobin strategies by trying to keep topic partition assignments on the same consumer from the previous assignment. This is accomplished by the having the consumer group leader use assignment information stored in the consumer `userdata` to learn about previous assignments.

This PR supports KIP-54 and the newer [KIP-341](https://cwiki.apache.org/confluence/display/KAFKA/KIP-341%3A+Update+Sticky+Assignor%27s+User+Data+Protocol) that uses consumer group generation numbers to reconcile conflicting information from consumer group members.

This assignor aims to be a 1:1 port of the [StickyAssignor](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/StickyAssignor.java) included in the official Java Kafka client, including all unit tests.